### PR TITLE
Lallement class

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -11,3 +11,4 @@ For info about stilism, particularly the relevant papers and caveats, see here: 
 reports the gradient in E(B-V)). The updated version (which also reports extinction as A_555nm, or roughly A_V), can be found at Vizier: 
 http://cdsarc.unistra.fr/viz-bin/cat/J/A+A/625/A135. Also, The map can be queried for a single line of sight or on a plane using the interface at https://astro.acri-st.fr/gaia_dev/.
 
+2021-04-05 Add class for Lallement's map. Fix issue with map queries due to initial misunderstanding of the grid of the map itself (slightly misaligned).

--- a/python/README.md
+++ b/python/README.md
@@ -9,5 +9,5 @@ https://github.com/jobovy/mwdust
 
 For info about stilism, particularly the relevant papers and caveats, see here: https://stilism.obspm.fr/ but notice this seems to point to an older version of the map (which 
 reports the gradient in E(B-V)). The updated version (which also reports extinction as A_555nm, or roughly A_V), can be found at Vizier: 
-http://cdsarc.unistra.fr/viz-bin/cat/J/A+A/625/A135
+http://cdsarc.unistra.fr/viz-bin/cat/J/A+A/625/A135. Also, The map can be queried for a single line of sight or on a plane using the interface at https://astro.acri-st.fr/gaia_dev/.
 

--- a/python/compareExtinctions.py
+++ b/python/compareExtinctions.py
@@ -42,7 +42,8 @@ or can be re-imported here."""
                  distances=np.array([]), \
                  objBovy = None, Rv=3.1, \
                  distMaxCoarsePc = 15000., \
-                 nDistBins = 400):
+                 nDistBins = 400,
+                 map_version='19'):
 
         # Sight line, max distance
         self.l = l
@@ -83,6 +84,9 @@ or can be re-imported here."""
         # extinction evaluates
         self.ebvL19 = np.array([])
         self.ebvBovy = np.array([])
+
+        # the version of LallementDustMap must be either '18' or '19', as string
+        self.lallementMap = stilism_local.LallementDustMap(version=map_version,Rv=Rv)
 
     def generateDistances(self, Verbose=False):
 
@@ -174,14 +178,16 @@ Bovy et al.
         # supply. This leads to an apparently redundant set of
         # keywords in the call.
         l19, dists, distLim \
-            = stilism_local.get_ebv_lallement(self.l, self.b, \
+            = self.lallementMap.get_ebv(self.l, self.b, \
                                               self.distMaxPc, \
                                               self.distMinPc, \
                                               self.distStepPc, \
                                               distances=self.distsPc)
 
         # Pass the l19 values, converted to E(B-V)
-        self.ebvL19 = l19 / self.Rv
+        ## new 2021-04-05: not needed since LallementDustMap handles conversion automatically
+        #self.ebvL19 = l19 / self.Rv
+        self.ebvL19 = l19
         
         # pass the distance array generated to the instance, IF it
         # wasn't already generated.

--- a/python/stilism_local.py
+++ b/python/stilism_local.py
@@ -252,7 +252,12 @@ if __name__ == '__main__':
     parser.add_argument('l',type=float)
     parser.add_argument('b',type=float)
     parser.add_argument('dist',type=float)
+    parser.add_argument('-m','--map-version',dest='map_version',choices=['18','19'],type=str, default='19')
+    parser.add_argument('-a','--return-av',dest='returnAv',action='store_true')
+    parser.add_argument('-v','--verbose',action='store_true')
     
     args = parser.parse_args()
     
-    get_ebv_lallement(args.l,args.b,args.dist)
+    lallement = LallementDustMap(args.map_version)
+    ebv = lallement.get_ebv(args.l,args.b,args.dist,returnAv=args.returnAv,Verbose=args.verbose)
+    print(ebv[0][-1])

--- a/python/stilism_local.py
+++ b/python/stilism_local.py
@@ -10,24 +10,144 @@ import h5py
 import numpy as np
 from scipy import interpolate
 
-print("Setting up the map.")
-#lallement = h5py.File('stilism_cube.h5',mode='r')
-lallement = h5py.File('stilism_cube_2.h5',mode='r')
-# lallement = h5py.File('map3D_GAIAdr2_feb2019.h5',mode='r')
-stilism = lallement['stilism']
-cube = stilism['cube_datas']
-ebv = cube[:]
+# lallement18 => 'stilism_cube.h5' --- returns E(B-V)
+# lallement19 => 'stilism_cube_2.h5' --- returns A0
 
-steps = cube.attrs['gridstep_values']
-center = cube.attrs['sun_position'] * steps
+class LallementDustMap(object):
+    map_path = {'18':'stilism_cube.h5','19':'stilism_cube_2.h5'}
+    EBV2A = {'18': 3.1, '19': 1}
+    A2EBV = {'18': 1, '19': 1/3.1}
 
-x0 = np.arange(ebv.shape[0])*steps[0] - center[0]
-y0 = np.arange(ebv.shape[1])*steps[1] - center[1]
-z0 = np.arange(ebv.shape[2])*steps[2] - center[2]
+    def __init__(self, version='19'):
+        """Initialize Lallement's dust map.
+        Beware that the version 2018 of the map has E(B-V) values while the 2019 one has
+        A0 values.
 
-rgi = interpolate.RegularGridInterpolator((x0,y0,z0),ebv, \
-                                          bounds_error=False, fill_value=0.)
-print("Setup complete.")
+        Args:
+            version (str): Either '18' (map of E(B-V)) or '19' (map of A0).
+        """
+        if version not in self.map_path:
+            message = "The version of the map must be either one of {}"\
+                        .format(", ".join(self.map_path.keys()))
+            raise ValueError(message)
+        self.version = version
+        map_path = self.map_path[self.version]
+        print("Setting up the map {}.".format(map_path))
+        dust_map = h5py.File(map_path, mode='r')
+
+        stilism = dust_map['stilism']
+        cube = stilism['cube_datas']
+        ebv = cube[:]
+
+        steps = cube.attrs['gridstep_values']
+        center = cube.attrs['sun_position'] * steps
+
+        self.x0 = np.arange(ebv.shape[0])*steps[0] - center[0]
+        self.y0 = np.arange(ebv.shape[1])*steps[1] - center[1]
+        self.z0 = np.arange(ebv.shape[2])*steps[2] - center[2]
+
+        if version == '19':
+            # At least for version 2019 of the map
+            self.x0 += 0.5*steps[0]
+            self.y0 += 0.5*steps[1]
+            self.z0 += 0.5*steps[2] 
+
+        self.rgi = interpolate.RegularGridInterpolator((self.x0, self.y0, self.z0), ebv, \
+                                                        bounds_error=False, fill_value=0.)
+        print("Setup complete.")
+
+    def find_max_distance(self, l=0, b=0, dists=np.array([])):
+
+        """Find the maximum distance in a supplied array that is within the
+        bounds of the extinction samples
+
+        Returns the maximum distance, the boolean array indicating which
+        distances are inside the cube, and the xyz coordinates along this
+        sight line from the distances.
+
+        Args:
+            l (float): Galactic latitude of the pointing.
+            b (array): Galactic longitude of the pointing.
+            dists (array): Array of distances
+
+        """
+
+        # Split out from get_ebv_lallement so that we can call this piece
+        # from other routines (e.g. when finding a sensible maximum
+        # distance)
+
+        if np.size(dists) < 1:
+            return 0., np.array([]), np.array([])
+
+        xyz = gal_to_xyz(l, b, dists)
+        bInCube = (np.abs(xyz[0]) < self.x0[-1]) & \
+                (np.abs(xyz[1]) < self.y0[-1]) & \
+                (np.abs(xyz[2]) < self.z0[-1])
+
+        distMax = np.max(dists[bInCube])
+
+        return distMax, bInCube, xyz
+        
+    def get_ebv(self, l,b,dist,dmin=0.5,dstep=5, \
+                        distances=np.array([]), returnAv=False,\
+                        Verbose=False):
+
+        # Now accespts an array of distances. The stepsize is computed
+        # element by element.
+        
+        # d_interp = np.arange(dmin,dist+0.1*dstep,dstep)
+        if np.size(distances) < 1:
+            d_interp = generate_distances(dist, dmin, dstep)
+        else:
+            d_interp = distances
+
+        # generate the distance step allowing for nonunuform bins
+        d_step = d_interp - np.roll(d_interp, 1)
+        d_step[0] = d_step[1] # the zeroth element needs specifying
+            
+        # distance, boolean and xyz refactored to a separate method
+        distMax, bInCube, xyz_interp = self.find_max_distance(l, b, d_interp)
+
+        
+        #xyz_interp = gal_to_xyz(l,b,d_interp)
+        
+        # WIC - update the selection for objects being inside the cube
+        #bInCube = (np.abs(xyz_interp[0])<x0[-1]) & \
+        #          (np.abs(xyz_interp[1])<y0[-1]) & \
+        #          (np.abs(xyz_interp[2])<z0[-1])
+        
+        #distMax = np.max(d_interp[bInCube])
+
+        # The regular grid interpolator returns zero for points outside
+        # the cube, which do not impact the sum along the sight line.
+        ebv_interp = self.rgi(xyz_interp)
+
+        if np.sum(~bInCube) > 0 and Verbose:
+            print("get_ebv_lallement INFO - some distances are beyond the cutoff %.1f pc for this sight line" % (distMax))
+        
+        #if not np.all( (np.abs(xyz_interp[0])<x0[-1]) & (np.abs(xyz_interp[1])<y0[-1]) & (np.abs(xyz_interp[2])<z0[-1])):
+        #    max_dist = z0[-1] / math.sin(math.radians(b))
+
+        #    # try max_dist_x
+        #    max_dist_x = x0[-1] / math.cos(math.radians(b))
+
+        #    max_dist = np.min([max_dist, max_dist_x])
+            
+        #    print("Queried distance of {}pc is out of the map. Maximum distance for this sightline is {:.1f}pc.".format(dist,max_dist))
+        #    return np.nan, d_interp
+        #ebv_interp = rgi(xyz_interp)
+        if returnAv:
+            fact = self.EBV2A[self.version]
+            if Verbose:
+                print("Converting map version {} to Av (fact={})".format(self.version,fact))
+            Av = np.cumsum(ebv_interp*d_step) * fact
+            return Av, d_interp, distMax # it is an E(B-V), must multiply by Rv
+
+        fact = self.A2EBV[self.version]
+        if Verbose:
+            print("Converting map version {} to E(B-V) (fact={})".format(self.version,fact))
+        ebv = np.cumsum(ebv_interp*d_step) * fact
+        return ebv, d_interp, distMax # it is an E(B-V), must multiply by Rv
 
 def gal_to_xyz(l,b,dist):
     l_rad = math.radians(l)

--- a/python/stilism_local.py
+++ b/python/stilism_local.py
@@ -29,27 +29,23 @@ class LallementDustMap(object):
                         .format(", ".join(self.map_path.keys()))
             raise ValueError(message)
         self.version = version
+
         map_path = self.map_path[self.version]
         print("Setting up the map {}.".format(map_path))
         dust_map = h5py.File(map_path, mode='r')
-
         stilism = dust_map['stilism']
         cube = stilism['cube_datas']
         ebv = cube[:]
-
         steps = cube.attrs['gridstep_values']
         center = cube.attrs['sun_position'] * steps
-
         self.x0 = np.arange(ebv.shape[0])*steps[0] - center[0]
         self.y0 = np.arange(ebv.shape[1])*steps[1] - center[1]
         self.z0 = np.arange(ebv.shape[2])*steps[2] - center[2]
-
         if version == '19':
             # At least for version 2019 of the map
             self.x0 += 0.5*steps[0]
             self.y0 += 0.5*steps[1]
             self.z0 += 0.5*steps[2] 
-
         self.rgi = interpolate.RegularGridInterpolator((self.x0, self.y0, self.z0), ebv, \
                                                         bounds_error=False, fill_value=0.)
 
@@ -184,83 +180,7 @@ def generate_distances(dmax=4300, dmin=0.5, dstep=5):
     # from other routines.
 
     return np.arange(dmin,dmax+0.1*dstep,dstep)
-    
-def find_max_distance(l=0, b=0, dists = np.array([])):
 
-    """Find the maximum distance in a supplied array that is within the
-bounds of the extinction samples
-
-    Returns the maximum distance, the boolean array indicating which
-    distances are inside the cube, and the xyz coordinates along this
-    sight line from the distances.
-
-    """
-
-    # Split out from get_ebv_lallement so that we can call this piece
-    # from other routines (e.g. when finding a sensible maximum
-    # distance)
-    
-    if np.size(dists) < 1:
-        return 0., np.array([]), np.array([])
-
-    xyz = gal_to_xyz(l,b,dists)
-    bInCube = (np.abs(xyz[0])<x0[-1]) & \
-              (np.abs(xyz[1])<y0[-1]) & \
-              (np.abs(xyz[2])<z0[-1])
-
-    distMax = np.max(dists[bInCube])
-
-    return distMax, bInCube, xyz
-    
-def get_ebv_lallement(l,b,dist,dmin=0.5,dstep=5, \
-                      distances=np.array([]), \
-                      Verbose=False):
-
-    # Now accespts an array of distances. The stepsize is computed
-    # element by element.
-    
-    # d_interp = np.arange(dmin,dist+0.1*dstep,dstep)
-    if np.size(distances) < 1:
-        d_interp = generate_distances(dist, dmin, dstep)
-    else:
-        d_interp = distances
-
-    # generate the distance step allowing for nonunuform bins
-    d_step = d_interp - np.roll(d_interp, 1)
-    d_step[0] = d_step[1] # the zeroth element needs specifying
-        
-    # distance, boolean and xyz refactored to a separate method
-    distMax, bInCube, xyz_interp = find_max_distance(l, b, d_interp)
-
-    
-    #xyz_interp = gal_to_xyz(l,b,d_interp)
-    
-    # WIC - update the selection for objects being inside the cube
-    #bInCube = (np.abs(xyz_interp[0])<x0[-1]) & \
-    #          (np.abs(xyz_interp[1])<y0[-1]) & \
-    #          (np.abs(xyz_interp[2])<z0[-1])
-    
-    #distMax = np.max(d_interp[bInCube])
-
-    # The regular grid interpolator returns zero for points outside
-    # the cube, which do not impact the sum along the sight line.
-    ebv_interp = rgi(xyz_interp)
-
-    if np.sum(~bInCube) > 0 and Verbose:
-        print("get_ebv_lallement INFO - some distances are beyond the cutoff %.1f pc for this sight line" % (distMax))
-    
-    #if not np.all( (np.abs(xyz_interp[0])<x0[-1]) & (np.abs(xyz_interp[1])<y0[-1]) & (np.abs(xyz_interp[2])<z0[-1])):
-    #    max_dist = z0[-1] / math.sin(math.radians(b))
-
-    #    # try max_dist_x
-    #    max_dist_x = x0[-1] / math.cos(math.radians(b))
-
-    #    max_dist = np.min([max_dist, max_dist_x])
-        
-    #    print("Queried distance of {}pc is out of the map. Maximum distance for this sightline is {:.1f}pc.".format(dist,max_dist))
-    #    return np.nan, d_interp
-    #ebv_interp = rgi(xyz_interp)
-    return np.cumsum(ebv_interp*d_step), d_interp, distMax # it is an E(B-V), must multiply by Rv
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
The initialization and querying of the map are now provided by a new class, `LallementDustMap`, from the `stilism_local` module.
The code to query the map now lives in the `get_ebv` method of the class, which works almost the same as the previous `get_ebv_lallement`, but for the new `returnAv` argument allowing the method to return AV instead of E(B-V).
The value of Rv defaults to 3.1, but can be changed at initialization, as an argument, as well as at any time it needs to be changed using the `set_Rv` method.
The `find_max_distance` function is now a method of the class, with the same name and arguments.

The command line interface has been updated to reflect the updates in the code.

Open problem: where to put the files of the maps. Depending on their location, the path of the two maps specified in the `map_path` class variable might have to be updated.