### PR TITLE
Fixed issue#7

### DIFF
--- a/python/compareExtinctions.py
+++ b/python/compareExtinctions.py
@@ -481,7 +481,9 @@ model.
 
     dmaxL19 = Maximum distance for Lallement et al. profile. Defaults
     to a very large number so the profile up to the intrinsic maximum
-    distance of the map is used.
+    distance of the map is used. Setting to zero disables Lallement's map.
+    Setting instead to -1 will use Bovy alone if non-zero for the line
+    of sight, otherwise only Lallement.
 
     planckMap = healpix 2d map of Planck E(B-V) predictions. Ignored
     if the query coords were not healpix, OR if Green's "dustmaps" is

--- a/python/compareExtinctions.py
+++ b/python/compareExtinctions.py
@@ -750,7 +750,7 @@ model.
     # the cases where Bovy does not seem to have coverage, scale L19
     # to the median Planck value.
     else:
-        if planck2DMed > 0.:
+        if planck2DMed > 0. and distCompare > 0:
             rvFactor = ebvL19Med[iMaxL19] / planck2DMed
         
     RvScaled = Rv * rvFactor

--- a/python/compareExtinctions.py
+++ b/python/compareExtinctions.py
@@ -783,6 +783,9 @@ model.
             # ebvHybrid[bBovBad] = ebvL19Med[bBovBad]/rvFactor
             ebvHybrid[bBovBad] = ebvL19scaled[bBovBad]
     
+    if np.all(ebvHybrid==0):
+        print("compareExtinctions.hybridSightline warning - The E(B-V) profile is zero everywhere!")
+
     if tellTime:
         t2 = time.time()
         dtBovy = t1 - t0

--- a/python/compareExtinctions.py
+++ b/python/compareExtinctions.py
@@ -766,16 +766,19 @@ model.
     # ebvL19scaled = quadFactor * ebvL19Med**2
     
     #ebvHybrid[b19] = ebvL19Med[b19]/rvFactor
+    bBovBad = ebvHybrid < minEBV
     if dmaxL19==-1:
         # Only use Lallement if Bovy is zero
         # distCompare is non-zero if Bovy is zero, use only Lallement
         if distCompare!=0:
             ebvHybrid = ebvL19Med
+        if len(bBovBad)>0:
+            print(("compareExtinctions.hybridSightline warning - Values in the E(B-V) "
+                  "Bovy profile are smaller than the requested minimum ."))
         # If distCompare is zero, Bovy is non-zero and will be the only profile used
     else:
         ebvHybrid[b19] = ebvL19scaled[b19]
     
-        bBovBad = ebvHybrid < minEBV
         # ebvHybrid[bBovBad] = ebvL19Med[bBovBad]/rvFactor
         ebvHybrid[bBovBad] = ebvL19scaled[bBovBad]
     

--- a/python/compareExtinctions.py
+++ b/python/compareExtinctions.py
@@ -698,7 +698,7 @@ model.
 
     # Use max distance provided by the user if required. 
     usemaxdist = False
-    if 0<dmaxL19<losCen.distLimPc:
+    if 0<=dmaxL19<losCen.distLimPc:
         print("Using user provided max distance for L+19.")
         distCompare = dmaxL19
         usemaxdist=True
@@ -709,7 +709,7 @@ model.
         if ebvBovyMed.sum()!=0:
             distCompare = 0
         # else use the full extent of the profile
-    else:
+    elif dmaxL19<0:
         raise NotImplemented("The value of dmax has to be either -1 or >=0, currently {}.".format(dmaxL19))
     
     if usemaxdist and doPlots:

--- a/python/compareExtinctions.py
+++ b/python/compareExtinctions.py
@@ -777,10 +777,11 @@ model.
                   "Bovy profile are smaller than the requested minimum ."))
         # If distCompare is zero, Bovy is non-zero and will be the only profile used
     else:
-        ebvHybrid[b19] = ebvL19scaled[b19]
-    
-        # ebvHybrid[bBovBad] = ebvL19Med[bBovBad]/rvFactor
-        ebvHybrid[bBovBad] = ebvL19scaled[bBovBad]
+        if distCompare>0:
+            ebvHybrid[b19] = ebvL19scaled[b19]
+        
+            # ebvHybrid[bBovBad] = ebvL19Med[bBovBad]/rvFactor
+            ebvHybrid[bBovBad] = ebvL19scaled[bBovBad]
     
     if tellTime:
         t2 = time.time()


### PR DESCRIPTION
Fixes #7 
Add option for the user to limit or completely ignore Lallement's profile.
In particular:

- `dmaxL19>0` will limit Lallement's profile to the given distance (use very large distance eg 1e6 to use the complete profile up to the limit of the map);
- `dmaxL19=0` will ignore Lallement's profile; **if Bovy is not available, the E(B_V) profile will be zero everywhere**;
- `dmaxL19=-1` will use only Bovy's profile where it is available, otherwise will use only Lallement's one.